### PR TITLE
Support storing the SubjectsTable in nwbfile.subjects_table

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,9 @@ subjects_table.add_row(
     weight="25g",
     individual_subj_link="relfilepath/subj_005.nwb"
 )
-```
 
-Add the `SubjectsTable` object to the NWB file with `nwbfile.add_acquisition(subjects_table)`. This adds the subjects
-table to the `acquisition` group of the NWB file. In the future, this will be changed so that the table can be added
-into the `general` group of the NWB file.
-
-```python
-nwbfile.add_acquisition(subjects_table)
+# Add the SubjectsTable to the NWB file
+nwbfile.subjects_table = subjects_table
 ```
 
 To add data that is specific to a selection of the subjects (fewer than the total number of subjects), use a
@@ -137,7 +132,7 @@ io = NWBHDF5IO("test_multi_subjects.nwb", "r")
 read_nwbfile = io.read()
 
 # Get the SubjectsTable in this NWB file
-read_subjects_table = read_nwbfile.get_acquisition("SubjectsTable")
+read_subjects_table = read_nwbfile.subjects_table
 
 # Get the SelectedSubjectsContainer
 read_selected_subjects_container = read_nwbfile.processing["behavior"]["selected_subjects_container_subjects_001_and_003"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ exclude = [
 line-length = 120
 
 [tool.ruff.lint.per-file-ignores]
+"src/pynwb/ndx_multisubjects/__init__.py" = ["E402"]
 "src/spec/create_extension_spec.py" = ["T201"]
 
 [tool.ruff.lint.mccabe]

--- a/spec/ndx-multisubjects.extensions.yaml
+++ b/spec/ndx-multisubjects.extensions.yaml
@@ -70,6 +70,14 @@ groups:
   doc: An extension to the NWBFile to store multiple subjects data. After 
     integration of ndx-multisubjects with the core schema, the NWBFile schema 
     should be updated to this type.
+  groups:
+  - name: general
+    doc: Experimental metadata...
+    groups:
+    - name: SubjectsTable
+      neurodata_type_inc: SubjectsTable
+      doc: Table to hold all metadata of subjects in an experiment.
+      quantity: '?'
 - neurodata_type_def: SelectSubjectsContainer
   neurodata_type_inc: NWBDataInterface
   doc: A container to hold data from a selection of subjects from the 

--- a/spec/ndx-multisubjects.namespace.yaml
+++ b/spec/ndx-multisubjects.namespace.yaml
@@ -14,4 +14,4 @@ namespaces:
   schema:
   - namespace: core
   - source: ndx-multisubjects.extensions.yaml
-  version: 0.1.1
+  version: 0.1.0

--- a/spec/ndx-multisubjects.namespace.yaml
+++ b/spec/ndx-multisubjects.namespace.yaml
@@ -14,4 +14,4 @@ namespaces:
   schema:
   - namespace: core
   - source: ndx-multisubjects.extensions.yaml
-  version: 0.1.0
+  version: 0.1.1

--- a/src/pynwb/ndx_multisubjects/__init__.py
+++ b/src/pynwb/ndx_multisubjects/__init__.py
@@ -1,5 +1,6 @@
 from importlib.resources import files
-from pynwb import load_namespaces, get_class
+
+from pynwb import get_class, load_namespaces
 
 # Get path to the namespace.yaml file with the expected location when installed not in editable mode
 __location_of_this_file = files(__name__)
@@ -12,17 +13,16 @@ if not __spec_path.exists():
 # Load the namespace
 load_namespaces(str(__spec_path))
 
-SubjectsTable = get_class("SubjectsTable", "ndx-multisubjects")
-NdxMultiSubjectsNWBFile = get_class("NdxMultiSubjectsNWBFile", "ndx-multisubjects")
-SelectSubjectsContainer = get_class("SelectSubjectsContainer", "ndx-multisubjects")
+from .ndx_multisubjects import NdxMultiSubjectsNWBFile, SelectSubjectsContainer, SubjectsTable
+from .ndx_multisubjects_nwb_file_io import NdxMultiSubjectsNWBFileMap
 
 __all__ = [
     "SubjectsTable",
     "NdxMultiSubjectsNWBFile",
     "SelectSubjectsContainer",
+    "NdxMultiSubjectsNWBFileMap",
 ]
 
-# from .ndx_multisubjects_nwb_file_io import NdxMultiSubjectsNWBFileMap
 
 # Remove these functions/modules from the package
 del load_namespaces, get_class, files, __location_of_this_file, __spec_path

--- a/src/pynwb/ndx_multisubjects/ndx_multisubjects.py
+++ b/src/pynwb/ndx_multisubjects/ndx_multisubjects.py
@@ -1,0 +1,26 @@
+from hdmf.utils import docval, get_docval
+from pynwb import NWBFile, get_class, register_class
+
+SubjectsTable = get_class("SubjectsTable", "ndx-multisubjects")
+SelectSubjectsContainer = get_class("SelectSubjectsContainer", "ndx-multisubjects")
+
+AutoNdxMultiSubjectsNWBFile = get_class("NdxMultiSubjectsNWBFile", "ndx-multisubjects")
+
+
+@register_class("NdxMultiSubjectsNWBFile", "ndx-multisubjects")
+class NdxMultiSubjectsNWBFile(AutoNdxMultiSubjectsNWBFile):
+    """An extension to the NWBFile to store multiple subjects data."""
+
+    # NOTE: After integration of ndx-multisubjects with the core schema, the NWBFile schema should be updated to this
+    # type.
+
+    __nwbfields__ = ({"name": "subjects_table", "child": True},)
+
+    @docval(
+        *get_docval(NWBFile.__init__),
+        {"name": "subjects_table", "type": SubjectsTable, "doc": "A SubjectsTable storing subjects", "default": None},
+    )
+    def __init__(self, **kwargs):
+        subjects_table = kwargs.pop("subjects_table", None)
+        super().__init__(**kwargs)
+        self.subjects_table = subjects_table

--- a/src/pynwb/ndx_multisubjects/ndx_multisubjects_nwb_file_io.py
+++ b/src/pynwb/ndx_multisubjects/ndx_multisubjects_nwb_file_io.py
@@ -1,18 +1,19 @@
-# from pynwb import register_map
-# from pynwb.io.file import NWBFileMap
-# from . import NdxMultiSubjectsNWBFile
+from pynwb.io.file import NWBFileMap
+from pynwb import register_map
+
+from . import NdxMultiSubjectsNWBFile
 
 
-# NOTE: When this extension is merged into the core NWB schema and software, this class will be merged
+# NOTE: When this extension is merged into the core NWB schema and software, this class should be merged
 # with the core NWBFileMap class.
-# @register_map(NdxMultiSubjectsNWBFile)
-# class NdxMultiSubjectsNWBFileMap(NWBFileMap):
+@register_map(NdxMultiSubjectsNWBFile)
+class NdxMultiSubjectsNWBFileMap(NWBFileMap):
 
-#     def __init__(self, spec):
-#         super().__init__(spec)
+    def __init__(self, spec):
+        super().__init__(spec)
 
-# Map the "subjects_table" attribute on the NdxMultiSubjectsNWBFile class to the SubjectsTable class
-# general_spec = self.spec.get_group("general")
-# self.unmap(general_spec)
-# self.unmap(general_spec.get_group("SubjectsTable"))
-# self.map_spec("subjects_table", general_spec.get_group("SubjectsTable"))
+        # Map the "subjects_table" attribute on the NdxMultiSubjectsNWBFile class to the SubjectsTable spec
+        general_spec = self.spec.get_group("general")
+        subjects_table_spec = general_spec.get_group("SubjectsTable")
+        self.unmap(subjects_table_spec)
+        self.map_spec("subjects_table", subjects_table_spec)

--- a/src/pynwb/tests/test_subjects_table.py
+++ b/src/pynwb/tests/test_subjects_table.py
@@ -1,14 +1,14 @@
 """Unit and integration tests for the neurodata types in ndx-multisubjects."""
 
-import numpy as np
-from uuid import uuid4
 from datetime import datetime, timezone
+from uuid import uuid4
 
-from pynwb import NWBHDF5IO, TimeSeries
-from pynwb.testing import TestCase, remove_test_file
 from hdmf.common import DynamicTableRegion
+import numpy as np
+from pynwb.testing import TestCase, remove_test_file
+from pynwb import NWBHDF5IO, TimeSeries
 
-from ndx_multisubjects import SubjectsTable, NdxMultiSubjectsNWBFile, SelectSubjectsContainer
+from ndx_multisubjects import NdxMultiSubjectsNWBFile, SelectSubjectsContainer, SubjectsTable
 
 
 class TestSubjectsTableConstructor(TestCase):
@@ -127,17 +127,14 @@ class TestSubjectsTableSimpleRoundtrip(TestCase):
             weight="25g",
             individual_subj_link="relfilepath/subj_003.nwb",
         )
-        self.nwbfile.add_acquisition(subjects_table)
-
-        # subjects_table.parent = self.nwbfile
+        self.nwbfile.subjects_table = subjects_table
 
         with NWBHDF5IO(self.path, mode="w") as io:
             io.write(self.nwbfile)
 
         with NWBHDF5IO(self.path, mode="r") as io:
             read_nwbfile = io.read()
-            read_subjects_table = read_nwbfile.acquisition["SubjectsTable"]
-            self.assertContainerEqual(subjects_table, read_subjects_table)
+            self.assertContainerEqual(subjects_table, read_nwbfile.subjects_table)
 
 
 class TestSelectSubjectsContainer(TestCase):
@@ -267,7 +264,7 @@ class TestSelectSubjectsContainerSimpleRoundtrip(TestCase):
             individual_subj_link="relfilepath/subj_005.nwb",
         )
 
-        self.nwbfile.add_acquisition(subjects_table)
+        self.nwbfile.subjects_table = subjects_table
 
         subjects = DynamicTableRegion(
             name="subjects",
@@ -292,8 +289,6 @@ class TestSelectSubjectsContainerSimpleRoundtrip(TestCase):
         )
 
         module.add(subjects_container)
-
-        # subjects_table.parent = self.nwbfile
 
         with NWBHDF5IO(self.path, mode="w") as io:
             io.write(self.nwbfile)

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -7,7 +7,7 @@ from pynwb.spec import NWBAttributeSpec, NWBDatasetSpec, NWBGroupSpec, NWBNamesp
 def main():
     ns_builder = NWBNamespaceBuilder(
         name="""ndx-multisubjects""",
-        version="""0.1.0""",
+        version="""0.1.1""",
         doc=(
             "Allow for multiple subjects to be represented in a single NWB file. "
             "This is for experiments where subjects are being recorded at the same time in the same session."
@@ -121,20 +121,20 @@ def main():
             "After integration of ndx-multisubjects with the core schema, "
             "the NWBFile schema should be updated to this type."
         ),
-        # groups=[
-        #     NWBGroupSpec(
-        #         name="general",
-        #         doc="Experimental metadata...",
-        #         groups=[
-        #             NWBGroupSpec(
-        #                 neurodata_type_inc="SubjectsTable",
-        #                 name = "SubjectsTable",
-        #                 doc="Table to hold all metadata of subjects in an experiment.",
-        #                 quantity = '?',
-        #             ),
-        #         ],
-        #     ),
-        # ],
+        groups=[
+            NWBGroupSpec(
+                name="general",
+                doc="Experimental metadata...",
+                groups=[
+                    NWBGroupSpec(
+                        neurodata_type_inc="SubjectsTable",
+                        name="SubjectsTable",
+                        doc="Table to hold all metadata of subjects in an experiment.",
+                        quantity="?",
+                    ),
+                ],
+            ),
+        ],
     )
 
     select_subjects_container_spec = NWBGroupSpec(

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -7,7 +7,7 @@ from pynwb.spec import NWBAttributeSpec, NWBDatasetSpec, NWBGroupSpec, NWBNamesp
 def main():
     ns_builder = NWBNamespaceBuilder(
         name="""ndx-multisubjects""",
-        version="""0.1.1""",
+        version="""0.1.0""",
         doc=(
             "Allow for multiple subjects to be represented in a single NWB file. "
             "This is for experiments where subjects are being recorded at the same time in the same session."


### PR DESCRIPTION
Fix #3. It turns out there was no issue in HDMF/PyNWB. We just needed to define a custom API class for `NdxMultisubjectsNWBFile`, just like in `NdxEventsNWBFile`, in order for the remapping to work and for setting the parent of the `SubjectsTable` to the `NdxMultisubjectsNWBFile` object to work.